### PR TITLE
Fix headline on mobile portrait width

### DIFF
--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -1,5 +1,6 @@
 /* #Site Styles
 ================================================== */
+h1 { white-space: nowrap;}
 img.middle { vertical-align: text-bottom;}
 
 input[type="text"],
@@ -60,7 +61,9 @@ select {
 	@media only screen and (min-width: 480px) and (max-width: 767px) {}
 
 	/* Mobile Portrait Size to Mobile Landscape Size (devices and browsers) */
-	@media only screen and (max-width: 479px) {}
+	@media only screen and (max-width: 479px) {
+		img.middle { display: block; margin: 0 auto;}
+	}
 
 
 /* #Font-Face


### PR DESCRIPTION
## The Problem

The h1 breaks on mobile portrait width, separating `<` and `Launchbot >` and pushing the latter to a new line.

![](http://i.imgur.com/cKdgZ.png)
## What this Pull Request does

It adds `white-space: nowrap;` to the h1 and centers the image inside it, keeping `< Launchbot >` together.

![](http://i.imgur.com/ZwB5x.png)
