### PR TITLE
add Wikipedia search

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,15 @@
           <input type="submit" id="searchSubmit" value="GO" />
         </fieldset>
       </form>
+      <hr>
+      <h3>Search Wikipedia</h3>
+      <p>My electrons are ready, let's learn something new!</p>
+      <form method="get" action="" id="searchWikiForm" name="searchWikiForm" target="_blank">
+        <fieldset>
+          <input type="text" name="search" maxlength="255" id="searchWiki" value="" />
+          <input type="submit" id="searchWikiSubmit" value="GO" />
+        </fieldset>
+      </form>
     </div>
     <div class="one-third column">
       <h3>Open Sets</h3>
@@ -124,7 +133,7 @@
   document.getElementById("siteSets").innerHTML = createSetList();
   document.getElementById("favoriteSites").innerHTML = getLinks(lb.favs).aList;
   if (lb.options.searchEngine !== 'https://www.google.com/search') document.searchForm.action = lb.options.searchEngine;
-
+  document.searchWikiForm.action = 'https://en.wikipedia.org/w/index.php';
 
   // Plugins
   // -------

--- a/index.html
+++ b/index.html
@@ -132,7 +132,8 @@
   // DOM manipulations
   document.getElementById("siteSets").innerHTML = createSetList();
   document.getElementById("favoriteSites").innerHTML = getLinks(lb.favs).aList;
-  if (lb.options.searchEngine !== 'https://www.google.com/search') document.searchForm.action = lb.options.searchEngine;
+  //if (lb.options.searchEngine !== 'https://www.google.com/search') 
+  document.searchForm.action = lb.options.searchEngine;
   document.searchWikiForm.action = 'https://en.wikipedia.org/w/index.php';
 
   // Plugins


### PR DESCRIPTION
Add Wikipedia search form, results open in a new tab. 
Tested on Windows 7 using:
- Chrome 49.0.2623.87 m
- Firefox 43.0.1
- IE 11.0.9600.18230
